### PR TITLE
Revert Gibbs sampler back to sequential

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,9 +23,9 @@ Authors@R:
     )
 Description: Implements an algorithm for Latent Dirichlet
     Allocation (LDA) using style conventions from the 'tidyverse' and
-    specifically 'tidymodels'. Gibbs sampler follows Newman et al. (2007)
-    <doi:10.5555/2981562.2981698>. Also implements several novel features for
-    LDA such as guided models and transfer learning.
+    specifically 'tidymodels'. Fitting is done via collapsed Gibbs sampling.
+    Also implements several novel features for LDA such as guided models and
+    transfer learning.
 License: MIT + file LICENSE
 URL: https://www.tidylda.com/
 BugReports: https://github.com/TommyJones/tidylda/issues

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -17,8 +17,8 @@
 #'   the only modification is that they are converted from matrices to nested
 #'   \code{std::vector} for speed, reliability, and thread safety. \code{dtm_in}
 #'   is transposed for speed when looping over columns. 
-create_lexicon <- function(Cd_in, Beta_in, dtm_in, alpha, freeze_topics, threads) {
-    .Call(`_tidylda_create_lexicon`, Cd_in, Beta_in, dtm_in, alpha, freeze_topics, threads)
+create_lexicon <- function(Cd_in, Beta_in, dtm_in, alpha, freeze_topics) {
+    .Call(`_tidylda_create_lexicon`, Cd_in, Beta_in, dtm_in, alpha, freeze_topics)
 }
 
 #' Main C++ Gibbs sampler for Latent Dirichlet Allocation
@@ -42,6 +42,7 @@ create_lexicon <- function(Cd_in, Beta_in, dtm_in, alpha, freeze_topics, threads
 #' @param freeze_topics bool if making predictions, set to \code{TRUE}
 #' @param optimize_alpha bool do you want to optimize alpha each iteration?
 #' @param threads unsigned integer, how many parallel threads?
+#'        For now, nothing is actually parallel
 #' @param verbose bool do you want to print out a progress bar?
 #' @details
 #'   Arguments ending in \code{_in} are copied and their copies modified in

--- a/R/utils.R
+++ b/R/utils.R
@@ -327,7 +327,7 @@ recover_counts_from_probs <- function(prob_matrix, prior_matrix, total_vector) {
 #'   \code{\link[tidylda]{refit.tidylda}}
 #' @param freeze_topics if \code{TRUE} does not update counts of tokens in topics.
 #'   This is \code{TRUE} for predictions.
-#' @param threads number of parallel threads; defaults to 1
+#' @param threads number of parallel threads, currently unused
 #' @param ... Additional arguments, currently unused
 #' @return
 #'   Returns a list with 5 elements: \code{docs}, \code{Zd}, \code{Cd}, \code{Cv},
@@ -422,8 +422,7 @@ initialize_topic_counts <- function(
       Beta_in = beta_initial,
       dtm_in = dtm, 
       alpha = alpha,
-      freeze_topics = freeze_topics,
-      threads = threads
+      freeze_topics = freeze_topics
     )
   
   lexicon

--- a/inst/include/tidylda_RcppExports.h
+++ b/inst/include/tidylda_RcppExports.h
@@ -25,17 +25,17 @@ namespace tidylda {
         }
     }
 
-    inline Rcpp::List create_lexicon(const IntegerMatrix& Cd_in, const NumericMatrix& Beta_in, const arma::sp_mat& dtm_in, const std::vector<double>& alpha, const bool& freeze_topics, const int& threads) {
-        typedef SEXP(*Ptr_create_lexicon)(SEXP,SEXP,SEXP,SEXP,SEXP,SEXP);
+    inline Rcpp::List create_lexicon(const IntegerMatrix& Cd_in, const NumericMatrix& Beta_in, const arma::sp_mat& dtm_in, const std::vector<double>& alpha, const bool& freeze_topics) {
+        typedef SEXP(*Ptr_create_lexicon)(SEXP,SEXP,SEXP,SEXP,SEXP);
         static Ptr_create_lexicon p_create_lexicon = NULL;
         if (p_create_lexicon == NULL) {
-            validateSignature("Rcpp::List(*create_lexicon)(const IntegerMatrix&,const NumericMatrix&,const arma::sp_mat&,const std::vector<double>&,const bool&,const int&)");
+            validateSignature("Rcpp::List(*create_lexicon)(const IntegerMatrix&,const NumericMatrix&,const arma::sp_mat&,const std::vector<double>&,const bool&)");
             p_create_lexicon = (Ptr_create_lexicon)R_GetCCallable("tidylda", "_tidylda_create_lexicon");
         }
         RObject rcpp_result_gen;
         {
             RNGScope RCPP_rngScope_gen;
-            rcpp_result_gen = p_create_lexicon(Shield<SEXP>(Rcpp::wrap(Cd_in)), Shield<SEXP>(Rcpp::wrap(Beta_in)), Shield<SEXP>(Rcpp::wrap(dtm_in)), Shield<SEXP>(Rcpp::wrap(alpha)), Shield<SEXP>(Rcpp::wrap(freeze_topics)), Shield<SEXP>(Rcpp::wrap(threads)));
+            rcpp_result_gen = p_create_lexicon(Shield<SEXP>(Rcpp::wrap(Cd_in)), Shield<SEXP>(Rcpp::wrap(Beta_in)), Shield<SEXP>(Rcpp::wrap(dtm_in)), Shield<SEXP>(Rcpp::wrap(alpha)), Shield<SEXP>(Rcpp::wrap(freeze_topics)));
         }
         if (rcpp_result_gen.inherits("interrupted-error"))
             throw Rcpp::internal::InterruptedException();

--- a/man/create_lexicon.Rd
+++ b/man/create_lexicon.Rd
@@ -4,7 +4,7 @@
 \alias{create_lexicon}
 \title{Make a lexicon for looping over in the gibbs sampler}
 \usage{
-create_lexicon(Cd_in, Beta_in, dtm_in, alpha, freeze_topics, threads)
+create_lexicon(Cd_in, Beta_in, dtm_in, alpha, freeze_topics)
 }
 \arguments{
 \item{Cd_in}{IntegerMatrix denoting counts of topics in documents}

--- a/man/fit_lda_c.Rd
+++ b/man/fit_lda_c.Rd
@@ -52,7 +52,8 @@ iteration?}
 
 \item{freeze_topics}{bool if making predictions, set to \code{TRUE}}
 
-\item{threads}{unsigned integer, how many parallel threads?}
+\item{threads}{unsigned integer, how many parallel threads?
+For now, nothing is actually parallel}
 
 \item{verbose}{bool do you want to print out a progress bar?}
 }

--- a/man/initialize_topic_counts.Rd
+++ b/man/initialize_topic_counts.Rd
@@ -39,7 +39,7 @@ topics in documents. Must be specified for updates as called by
 \item{freeze_topics}{if \code{TRUE} does not update counts of tokens in topics.
 This is \code{TRUE} for predictions.}
 
-\item{threads}{number of parallel threads; defaults to 1}
+\item{threads}{number of parallel threads, currently unused}
 
 \item{...}{Additional arguments, currently unused}
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -15,8 +15,8 @@ Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
 #endif
 
 // create_lexicon
-Rcpp::List create_lexicon(const IntegerMatrix& Cd_in, const NumericMatrix& Beta_in, const arma::sp_mat& dtm_in, const std::vector<double>& alpha, const bool& freeze_topics, const int& threads);
-static SEXP _tidylda_create_lexicon_try(SEXP Cd_inSEXP, SEXP Beta_inSEXP, SEXP dtm_inSEXP, SEXP alphaSEXP, SEXP freeze_topicsSEXP, SEXP threadsSEXP) {
+Rcpp::List create_lexicon(const IntegerMatrix& Cd_in, const NumericMatrix& Beta_in, const arma::sp_mat& dtm_in, const std::vector<double>& alpha, const bool& freeze_topics);
+static SEXP _tidylda_create_lexicon_try(SEXP Cd_inSEXP, SEXP Beta_inSEXP, SEXP dtm_inSEXP, SEXP alphaSEXP, SEXP freeze_topicsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::traits::input_parameter< const IntegerMatrix& >::type Cd_in(Cd_inSEXP);
@@ -24,16 +24,15 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const arma::sp_mat& >::type dtm_in(dtm_inSEXP);
     Rcpp::traits::input_parameter< const std::vector<double>& >::type alpha(alphaSEXP);
     Rcpp::traits::input_parameter< const bool& >::type freeze_topics(freeze_topicsSEXP);
-    Rcpp::traits::input_parameter< const int& >::type threads(threadsSEXP);
-    rcpp_result_gen = Rcpp::wrap(create_lexicon(Cd_in, Beta_in, dtm_in, alpha, freeze_topics, threads));
+    rcpp_result_gen = Rcpp::wrap(create_lexicon(Cd_in, Beta_in, dtm_in, alpha, freeze_topics));
     return rcpp_result_gen;
 END_RCPP_RETURN_ERROR
 }
-RcppExport SEXP _tidylda_create_lexicon(SEXP Cd_inSEXP, SEXP Beta_inSEXP, SEXP dtm_inSEXP, SEXP alphaSEXP, SEXP freeze_topicsSEXP, SEXP threadsSEXP) {
+RcppExport SEXP _tidylda_create_lexicon(SEXP Cd_inSEXP, SEXP Beta_inSEXP, SEXP dtm_inSEXP, SEXP alphaSEXP, SEXP freeze_topicsSEXP) {
     SEXP rcpp_result_gen;
     {
         Rcpp::RNGScope rcpp_rngScope_gen;
-        rcpp_result_gen = PROTECT(_tidylda_create_lexicon_try(Cd_inSEXP, Beta_inSEXP, dtm_inSEXP, alphaSEXP, freeze_topicsSEXP, threadsSEXP));
+        rcpp_result_gen = PROTECT(_tidylda_create_lexicon_try(Cd_inSEXP, Beta_inSEXP, dtm_inSEXP, alphaSEXP, freeze_topicsSEXP));
     }
     Rboolean rcpp_isInterrupt_gen = Rf_inherits(rcpp_result_gen, "interrupted-error");
     if (rcpp_isInterrupt_gen) {
@@ -106,7 +105,7 @@ RcppExport SEXP _tidylda_fit_lda_c(SEXP DocsSEXP, SEXP Zd_inSEXP, SEXP Cd_inSEXP
 static int _tidylda_RcppExport_validate(const char* sig) { 
     static std::set<std::string> signatures;
     if (signatures.empty()) {
-        signatures.insert("Rcpp::List(*create_lexicon)(const IntegerMatrix&,const NumericMatrix&,const arma::sp_mat&,const std::vector<double>&,const bool&,const int&)");
+        signatures.insert("Rcpp::List(*create_lexicon)(const IntegerMatrix&,const NumericMatrix&,const arma::sp_mat&,const std::vector<double>&,const bool&)");
         signatures.insert("Rcpp::List(*fit_lda_c)(const std::vector<std::vector<std::size_t>>&,const std::vector<std::vector<std::size_t>>&,const IntegerMatrix&,const IntegerMatrix&,const std::vector<long>&,const std::vector<double>,const NumericMatrix&,const std::size_t&,const int&,const bool&,const bool&,const NumericMatrix&,const bool&,const std::size_t&,const bool&)");
     }
     return signatures.find(sig) != signatures.end();
@@ -121,7 +120,7 @@ RcppExport SEXP _tidylda_RcppExport_registerCCallable() {
 }
 
 static const R_CallMethodDef CallEntries[] = {
-    {"_tidylda_create_lexicon", (DL_FUNC) &_tidylda_create_lexicon, 6},
+    {"_tidylda_create_lexicon", (DL_FUNC) &_tidylda_create_lexicon, 5},
     {"_tidylda_fit_lda_c", (DL_FUNC) &_tidylda_fit_lda_c, 15},
     {"_tidylda_RcppExport_registerCCallable", (DL_FUNC) &_tidylda_RcppExport_registerCCallable, 0},
     {NULL, NULL, 0}


### PR DESCRIPTION
Doing this b/c (a) doing parallel sampling in a way that respects the user's seed and conforms to CRAN policies was more trouble than it was worth because (b) parallel sampling (which was "approximate Gibbs" a-la Newman et al., 2009) significantly decreased goodness of fit by several metrics I usually rely on.